### PR TITLE
fix: disable SSL plugin in production builds for GitHub Pages compatibility

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,11 @@ import basicSsl from '@vitejs/plugin-basic-ssl'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), basicSsl()],
+  plugins: [
+    react(),
+    // Only use SSL plugin in development mode to avoid GitHub Pages deployment issues
+    process.env.NODE_ENV !== 'production' ? basicSsl() : null
+  ].filter(Boolean),
   base: '/webxr-instrument/',
   server: {
     host: '0.0.0.0',


### PR DESCRIPTION
Fixes GitHub Pages deployment failure by disabling SSL plugin in production builds.

## Changes
- Modified `vite.config.ts` to only use `basicSsl())` plugin in development mode
- This resolves SSL configuration conflicts during GitHub Pages deployment
- Production builds now skip SSL plugin to prevent deployment failures

## Manual Steps Still Needed
⚠️ Update `.github/workflows/deploy.yml` timeout values from 10 to 15 minutes (lines 20 and 50)

Closes #1

Generated with [Claude Code](https://claude.ai/code)